### PR TITLE
issue 7: Geolocation hook 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,9 +17,6 @@ function App() {
           <MobileLayout>
             <BrowserRouter>
               <Header />
-              <Header />
-              <Header />
-              <Header />
               <Routes>
                 <Route path="/login" element={<LoginPage />}></Route>
               </Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import GlobalStyle from "./styles/GlobalStyle";
-import { MainLayout } from "./styles/Layout.styles";
+import { MainLayout, MobileLayout } from "./styles/Layout.styles";
 import Header from "./components/header/Header";
 import LoginPage from "./pages/LoginPage/LoginPage";
 
@@ -14,12 +14,17 @@ function App() {
       <QueryClientProvider client={queryClient}>
         <GlobalStyle />
         <MainLayout>
-          <BrowserRouter>
-            <Header />
-            <Routes>
-              <Route path="/login" element={<LoginPage />}></Route>
-            </Routes>
-          </BrowserRouter>
+          <MobileLayout>
+            <BrowserRouter>
+              <Header />
+              <Header />
+              <Header />
+              <Header />
+              <Routes>
+                <Route path="/login" element={<LoginPage />}></Route>
+              </Routes>
+            </BrowserRouter>
+          </MobileLayout>
         </MainLayout>
         <ReactQueryDevtools />
       </QueryClientProvider>

--- a/src/components/header/Header.styles.tsx
+++ b/src/components/header/Header.styles.tsx
@@ -1,3 +1,8 @@
 import styled from "styled-components";
 
-export const HeaderLayout = styled.header``;
+export const HeaderLayout = styled.header`
+  width: 100%;
+  height: 500px;
+  color: black;
+  background-color: #ffacac5e;
+`;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,8 +1,16 @@
+import useGeoLocation from "../../hooks/useGeoLocation";
 import * as Style from "./Header.styles";
 
 //현재 페이지를 추적해서 login페이지인지 아닌지 판단 로직 필요
 //로그인 페이지의 Header는 기본 Header랑 다름
 const Header = () => {
+  const location = useGeoLocation();
+  if (!location.error) {
+    console.log(location.coordinates?.lat, location.coordinates?.lng);
+  } else {
+    console.log(location.error.message);
+  }
+
   return <Style.HeaderLayout>헤더임</Style.HeaderLayout>;
 };
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,9 +1,9 @@
-import * as H from "./Header.styles";
+import * as Style from "./Header.styles";
 
 //현재 페이지를 추적해서 login페이지인지 아닌지 판단 로직 필요
 //로그인 페이지의 Header는 기본 Header랑 다름
 const Header = () => {
-    return <H.HeaderLayout>헤더임</H.HeaderLayout>;
+  return <Style.HeaderLayout>헤더임</Style.HeaderLayout>;
 };
 
 export default Header;

--- a/src/hooks/useCafeQuery.tsx
+++ b/src/hooks/useCafeQuery.tsx
@@ -8,7 +8,8 @@ const fetchCafeList = async () => {
   return response.data;
 };
 
-export const useCafeListQuery = () => {
+//카페 리스트 불러오는 커스텀 훅
+export const useCafeQuery = () => {
   const {
     isLoading: isCafeListLoading,
     isError: isCafeListError,

--- a/src/hooks/useGeoLocation.tsx
+++ b/src/hooks/useGeoLocation.tsx
@@ -1,0 +1,45 @@
+import { useState, useEffect } from "react";
+import { locationType } from "../types/gelocationType";
+
+const useGeoLocation = () => {
+  const [location, setLocation] = useState<locationType>({
+    loaded: false,
+    coordinates: { lat: 0, lng: 0 },
+  });
+
+  //성공했을 때
+  const onSuccess = (props: { coords: { latitude: number; longitude: number } }) => {
+    setLocation({
+      loaded: true,
+      coordinates: {
+        lat: props.coords.latitude,
+        lng: props.coords.longitude,
+      },
+    });
+  };
+
+  //실패했을 때
+  const onError = (error: { code: number; message: string }) => {
+    setLocation({
+      loaded: true,
+      error,
+    });
+  };
+
+  useEffect(() => {
+    if (!("geolocation" in navigator)) {
+      onError({
+        code: 0,
+        message: "Geolocation이 제공되지 않는 브라우저 입니다.",
+      });
+    }
+    //HTML5의 navigator.gelocation.getCurrentPosition API 사용
+    //성공시 onSuccess 호출하고 실패시 onError 호출하게 됨. (onSuccess, onError = 콜백 함수)
+    //onSuccess는 coords 객체를 포함한 객체를 props로 전달받고 onError는 에러 메세지와 코드를 포함한 객체를 props로 전달받음
+    navigator.geolocation.getCurrentPosition(onSuccess, onError);
+  }, []);
+
+  return location;
+};
+
+export default useGeoLocation;

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -23,7 +23,7 @@ time, mark, audio, video {
 }
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure, 
-footer, header, hgroup, menu, nav, section {
+footer, header, hgroup, menu, nav, section, main {
 	display: block;
 }
 body {

--- a/src/styles/Layout.styles.tsx
+++ b/src/styles/Layout.styles.tsx
@@ -1,9 +1,14 @@
 import styled from "styled-components";
 
-//현재는 모바일 용으로 Layout 설정
-//웹 UI 구현 시, mediaQuery 도입해야 함
 export const MainLayout = styled.main`
+  width: 100vw;
+  height: 100vh;
+  overflow: auto;
+`;
+
+export const MobileLayout = styled.div`
   max-width: 390px; // 피그마 보고 수정 예정
   min-width: 320px; // 피그마 보고 수정 예정
   margin: 0 auto;
+  background-color: aliceblue;
 `;

--- a/src/types/gelocationType.tsx
+++ b/src/types/gelocationType.tsx
@@ -1,0 +1,5 @@
+export interface locationType {
+  loaded: boolean;
+  coordinates?: { lat: number; lng: number };
+  error?: { code: number; message: string };
+}


### PR DESCRIPTION
#7
## 🌱 기능 구현
### Geolocation 커스텀 훅
- 비동기로 사용자의 위치를 받아오고 개별 로직이기 때문에 커스텀 훅으로 분리
- 성공 시 : onSuccess 콜백 함수 호출로 위도와 경도 설정
- 실패 시 : onError 콜백 함수 호출로 에러 코드와 에러 메세지 설정
  - 실패 경우 : 사용자의 위치 공유 기능 거부

## 🔧 수정
### Layout 및 Header css 수정
- 전체 Layout이 화면 가운데에 위치하기 위해 기존의 MainLayout을 부모, MobileLayout을 추가 및 자식으로 설정
- 100vh가 넘어갈 경우 스크롤이 브라우저에 생기도록 구현 -> 캐치테이블 UI 참고